### PR TITLE
Fix crash on scan for WF-2630

### DIFF
--- a/net.epson.epsonscan2.json
+++ b/net.epson.epsonscan2.json
@@ -152,7 +152,8 @@
                         "patches/0001-Fix-prefix-to-flatpak.patch",
                         "patches/0002-Fix-crash.patch",
                         "patches/0003-Use-XDG-open-to-open-the-directory.patch",
-                        "patches/0004-Fix-a-crash-on-an-OOB-container-access.patch"
+                        "patches/0004-Fix-a-crash-on-an-OOB-container-access.patch",
+                        "patches/0005-Fix-folder-creation-crash.patch"
                     ]
                 },
                 {

--- a/patches/0005-Fix-folder-creation-crash.patch
+++ b/patches/0005-Fix-folder-creation-crash.patch
@@ -1,0 +1,11 @@
+diff -ruN orig/src/CommonUtility/utils/PathUtils.cpp new/src/CommonUtility/utils/PathUtils.cpp
+--- orig/src/CommonUtility/utils/PathUtils.cpp	2024-05-21 11:16:01.000000000 +0200
++++ new/src/CommonUtility/utils/PathUtils.cpp	2025-01-21 16:18:36.420143443 +0100
+@@ -606,7 +606,6 @@
+       else
+       {
+        bResult = TRUE;
+-       break;
+       }
+      }
+ #endif


### PR DESCRIPTION
Fix crash occurring during scan due to broken recursive folder creation logic.

The function "ES_MakeFolder" wrongly returned after creating the first folder instead of the whole path. The Win32 code path confirms the unintended UNIX behavior.

This results in  a segfault caused by inability to create temporary files. As a result, no file is saved after a scan.

Issue and fix tested on a WF-2630.